### PR TITLE
Fix RDS access to Secrets Manager

### DIFF
--- a/cfn/add-users.template
+++ b/cfn/add-users.template
@@ -36,6 +36,9 @@ Parameters:
   ProxySecurityGroup:
     Type: String # Has to be type String as NoProxy has 'NA' value
 
+  UsersToCreate:
+    Type: Number
+
 Conditions:
   IsRDSProxy: !Equals [!Ref CreateRDSProxy, true]
 
@@ -53,7 +56,7 @@ Resources:
         Variables:
           ENDPOINT: !Ref Endpoint
           USER: admin
-          USERS_TO_CREATE: 200
+          USERS_TO_CREATE: !Ref UsersToCreate
           REGION: !Sub ${AWS::Region}
           SECRETARN: !Ref DBSecretArn
           DATABASE: main
@@ -91,7 +94,7 @@ Resources:
         Variables:
           ENDPOINT: !Ref Endpoint
           USER: admin
-          USERS_TO_CREATE: 200
+          USERS_TO_CREATE: !Ref UsersToCreate
           NUMBER_OF_ROWS: 1000
           REGION: !Sub ${AWS::Region}
           DATABASE: main

--- a/cfn/main.template
+++ b/cfn/main.template
@@ -23,6 +23,7 @@ Metadata:
           default: Load test configuration
         Parameters:
           - CreateLoadTest
+          - UsersToCreate
           - LocustAmiId
           - LocustInstanceType
           - LocustVersion
@@ -42,6 +43,8 @@ Metadata:
         deafult: Infrastructure Environment
       CreateLoadTest:
         default: Create Load Test Stack
+      UsersToCreate:
+        default: Number of users to create
       LocustAmiId:
         default: Latest Amazon Linux AMI
       LocustInstanceType:
@@ -66,6 +69,13 @@ Parameters:
       - true
     Default: true
     ConstraintDescription: Must specify 'true' or 'false'
+
+  UsersToCreate:
+    Description: Each proxy can have up to 200 associated Secrets Manager secrets. Thus, each proxy can connect to with up to 200 different user accounts at any given time. Allowed values are 1-200
+    Type: String
+    Default: 200
+    AllowedPattern: ^(20[0]|1[0-9][0-9]|[1-9]?[1-9])$
+    ConstraintDescription: Users parameter must be in the range 1-199
 
   AvailabilityZones:
     Description: The list of Availability Zones to use for the subnets in the VPC. Select two Availability Zones from the list.
@@ -368,6 +378,7 @@ Resources:
         DBSecretArn: !GetAtt ProxyRDSStack.Outputs.DBSecret
         DBProxyName: !GetAtt ProxyRDSStack.Outputs.DBProxyName
         DBProxyArn: !GetAtt ProxyRDSStack.Outputs.DBProxyArn
+        UsersToCreate: !Ref UsersToCreate
       Tags:
         - Key: Project
           Value: !FindInMap [StackMap, ProxyMap, ResourceTags]
@@ -391,6 +402,7 @@ Resources:
         DBSecretArn: !GetAtt NoProxyRDSStack.Outputs.DBSecret
         DBProxyName: NA
         DBProxyArn: NA
+        UsersToCreate: !Ref UsersToCreate
       Tags:
         - Key: Project
           Value: !FindInMap [StackMap, NoProxyMap, ResourceTags]

--- a/cfn/rds.template
+++ b/cfn/rds.template
@@ -177,19 +177,21 @@ Resources:
                   - secretsmanager:GetSecretValue
                 Resource:
                   - !Ref DBSecret
+                  - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:Amazon_rds_proxy_multitenant_load_test/Proxy_secret_for_user*
               - Sid: DecryptSecretValue
                 Effect: Allow
                 Action:
                   - kms:Decrypt
-                Resource: # Get the DB Secret name without arn bit
+                Resource:
                   - !Join
                     - ""
                     - - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/
                       - !Select
                         - 6
                         - !Split
-                          - ':'
+                          - ':' # Get the DB Secret name without arn bit
                           - !Ref DBSecret
+                  - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*
                 Condition:
                   StringEquals:
                     kms:ViaService: !Sub secretsmanager.${AWS::Region}.amazonaws.com


### PR DESCRIPTION
*Description of changes:*
 This PR fixes the access issue to RDS proxy. After a dive deep, it was found out that API call `modify_db_proxy` creates completely new list of authenticated user. This means, the initial admin secret is removed from proxy "authenticators" and causes proxy losing the access to the admin secret. 

Given the RDS policy was scooped down as per [AWS RDS documentation guide](https://docs.amazonaws.cn/en_us/AmazonRDS/latest/UserGuide/rds-proxy.html#rds-proxy-iam-setup), this can be no longer used in particular scenario, unless there is a further improvement made to `cr_add_users.py` function. See the RDS Proxy policy at `cfn/rds.template` line 159 -198.

Recommendation: Create customer manged key (CMK) and use it instead of default secrets manager key for secret encryption. Then follow the guide above to lock down the kms key with created `key_id`.
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
