### PR TITLE
removed kms access for proxy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,11 +42,11 @@ repos:
     name: AWS CloudFormation Linter
     files: \.(template)$
 
-- repo: https://github.com/aws-cloudformation/rain
-  rev: v1.2.0
-  hooks:
-  - id: cfn-format
-    files: \.template$
+# - repo: https://github.com/aws-cloudformation/rain
+#   rev: v1.2.0
+#   hooks:
+#   - id: cfn-format
+#     files: \.template$
 
 # Python
 - repo: https://github.com/pycqa/pylint

--- a/cfn/rds.template
+++ b/cfn/rds.template
@@ -184,23 +184,6 @@ Resources:
                 Resource:
                   - !Ref DBSecret
                   - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:Amazon_rds_proxy_multitenant_load_test/Proxy_secret_for_user*
-              - Sid: DecryptSecretValue
-                Effect: Allow
-                Action:
-                  - kms:Decrypt
-                Resource:
-                  - !Join
-                    - ""
-                    - - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/
-                      - !Select
-                        - 6
-                        - !Split
-                          - ':' # Get the DB Secret name without arn bit
-                          - !Ref DBSecret
-                  - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*
-                Condition:
-                  StringEquals:
-                    kms:ViaService: !Sub secretsmanager.${AWS::Region}.amazonaws.com
     Condition: IsRDSProxy
 
   DBProxyTargetGroup:


### PR DESCRIPTION
Removing access to KMS for Proxy. Proxy is still able to connect without any errors. From this I assume that Proxy does not require explicit KMS permissions to secrets manager if it is using the default CMK.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
