### PR TITLE
lambda name change

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.4
+current_version = 0.0.5
 commit = False
 tag = False
 

--- a/README.md
+++ b/README.md
@@ -70,16 +70,16 @@ Whilst you can modify the name of the stack, do not increase the length of its n
 
 When completed, click *Next*
 1. [Configure stack options](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html) if desired, then click *Next*.
-2. On the review you screen, you must check the boxes for:
+1. On the review you screen, you must check the boxes for:
    * "*I acknowledge that AWS CloudFormation might create IAM resources*"
    * "*I acknowledge that AWS CloudFormation might create IAM resources with custom names*"
    * "*I acknowledge that AWS CloudFormation might require the following capability: CAPABILITY_AUTO_EXPAND*"
 
    These are required to allow CloudFormation to create a Role to allow access to resources needed by the stack and name the resources in a dynamic way.
-3. Click *Create Stack*
-4. Wait for the CloudFormation stack to launch. This will take around 30 minutes. Completion is indicated when the "Stack status" is "*CREATE_COMPLETE*".
+1. Click *Create Stack*
+1. Wait for the CloudFormation stack to launch. This will take around 30 minutes. Completion is indicated when the "Stack status" is "*CREATE_COMPLETE*".
    * You can monitor the stack creation progress in the "Events" tab.
-5. Note the *LocustAddress* and *APIGatewayURL* displayed in the *Outputs* tab of the main stack. These can be used to access the Locust dashboard and direct the load  test towards the created Amazon API Gateway.
+1. Note the *LocustAddress* and *APIGatewayURL* displayed in the *Outputs* tab of the main stack. These can be used to access the Locust dashboard and direct the load  test towards the created Amazon API Gateway.
 
 ## Local Development
 See the [Local Development](docs/LOCAL_DEVELOPMENT.md) guide to get a copy of the project up and running on your local machine for development and testing purposes.
@@ -89,9 +89,9 @@ See the [Local Development](docs/LOCAL_DEVELOPMENT.md) guide to get a copy of th
 To remove the stack:
 
 1. Open the AWS CloudFormation Console
-2. Click the *rds-proxy-load-test* project, right-click and select "*Delete Stack*"
-3. Your stack will take some time to be deleted. You can track its progress in the "Events" tab.
-4. When it is done, the status will change from "DELETE_IN_PROGRESS" to "DELETE_COMPLETE". It will then disappear from the list.
+1. Click the *rds-proxy-load-test* project, right-click and select "*Delete Stack*"
+1. Your stack will take some time to be deleted. You can track its progress in the "Events" tab.
+1. When it is done, the status will change from "DELETE_IN_PROGRESS" to "DELETE_COMPLETE". It will then disappear from the list.
 
 ## Detailed Pricing
 This sample is intended to be deployed only for as long as is strictly necessary, to avoid incurring additional costs. As soon as the load test is completed, the stack should be deleted (see 'Clean up' above). Note that all pricing is estimated based on the us-east-1 region, and without the Free Tier.

--- a/cfn/access-function.template
+++ b/cfn/access-function.template
@@ -60,7 +60,7 @@ Resources:
           CLUSTER_ENDPOINT_RESOURCE: !Sub arn:${AWS::Partition}:rds-db:${AWS::Region}:${AWS::AccountId}:dbuser:${ClusterEndpointResourceId}/user
           REGION: !Ref AWS::Region
           IAM_ARN: !GetAtt STSRole.Arn
-      FunctionName: !Sub fn-python-${AWS::StackName}
+      FunctionName: fn-python-loadtest-access-function-987123
       Handler: access.lambda_handler
       Layers:
         - !Ref LayerVersionArn
@@ -93,7 +93,7 @@ Resources:
           CLUSTER_ENDPOINT_RESOURCE: !Sub arn:${AWS::Partition}:rds-db:${AWS::Region}:${AWS::AccountId}:dbuser:${ClusterEndpointResourceId}/user
           REGION: !Ref AWS::Region
           IAM_ARN: !GetAtt STSRole.Arn
-      FunctionName: !Sub fn-nodejs-${AWS::StackName}
+      FunctionName: fn-nodejs-loadtest-access-function-987123
       Handler: index.handler
       Layers:
         - !Ref LayerVersionArn

--- a/cfn/access-function.template
+++ b/cfn/access-function.template
@@ -43,7 +43,7 @@ Conditions:
 Transform: AWS::Serverless-2016-10-31
 
 Resources:
-  PythonLambdaFunction:
+  PythonFunction:
     Type: AWS::Serverless::Function
     DependsOn:
       - XraySeviceAccessPolicy
@@ -60,7 +60,7 @@ Resources:
           CLUSTER_ENDPOINT_RESOURCE: !Sub arn:${AWS::Partition}:rds-db:${AWS::Region}:${AWS::AccountId}:dbuser:${ClusterEndpointResourceId}/user
           REGION: !Ref AWS::Region
           IAM_ARN: !GetAtt STSRole.Arn
-      FunctionName: fn-python-loadtest-access-function-987123
+      FunctionName: !Sub fn-python-${AWS::StackName}
       Handler: access.lambda_handler
       Layers:
         - !Ref LayerVersionArn
@@ -76,7 +76,7 @@ Resources:
           - !Ref PrivateSubnet2
     Condition: IsPython
 
-  NodeJsLambdaFunction:
+  NodeJsFunction:
     Type: AWS::Serverless::Function
     DependsOn:
       - XraySeviceAccessPolicy
@@ -93,7 +93,7 @@ Resources:
           CLUSTER_ENDPOINT_RESOURCE: !Sub arn:${AWS::Partition}:rds-db:${AWS::Region}:${AWS::AccountId}:dbuser:${ClusterEndpointResourceId}/user
           REGION: !Ref AWS::Region
           IAM_ARN: !GetAtt STSRole.Arn
-      FunctionName: fn-nodejs-loadtest-access-function-987123
+      FunctionName: !Sub fn-nodejs-${AWS::StackName}
       Handler: index.handler
       Layers:
         - !Ref LayerVersionArn
@@ -245,10 +245,10 @@ Resources:
         - !Ref STSRole
 
 Outputs:
-  PythonLambdaFunction:
-    Value: !Ref PythonLambdaFunction
+  PythonFunction:
+    Value: !Ref PythonFunction
     Condition: IsPython
 
-  NodeJsLambdaFunction:
-    Value: !Ref NodeJsLambdaFunction
+  NodeJsFunction:
+    Value: !Ref NodeJsFunction
     Condition: IsNodeJs

--- a/cfn/main.template
+++ b/cfn/main.template
@@ -335,7 +335,7 @@ Resources:
           Value: !Ref Environment
     Condition: IsLoadTest
 
-  ProxyLambdaAccessStack:
+  ProxyAccessStack:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: access-function.template
@@ -359,7 +359,7 @@ Resources:
         - Key: Environment
           Value: !Ref Environment
 
-  NoProxyLambdaAccessStack:
+  NoProxyAccessStack:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: access-function.template
@@ -439,12 +439,12 @@ Resources:
       Parameters:
         ProxyAccessLambda: !If
           - IsPython
-          - !GetAtt ProxyLambdaAccessStack.Outputs.PythonLambdaFunction
-          - !GetAtt ProxyLambdaAccessStack.Outputs.NodeJsLambdaFunction
+          - !GetAtt ProxyAccessStack.Outputs.PythonFunction
+          - !GetAtt ProxyAccessStack.Outputs.NodeJsFunction
         NoProxyAccessLambda: !If
           - IsPython
-          - !GetAtt NoProxyLambdaAccessStack.Outputs.PythonLambdaFunction
-          - !GetAtt NoProxyLambdaAccessStack.Outputs.NodeJsLambdaFunction
+          - !GetAtt NoProxyAccessStack.Outputs.PythonFunction
+          - !GetAtt NoProxyAccessStack.Outputs.NodeJsFunction
         ProxyClusterName: !GetAtt ProxyRDSStack.Outputs.DBClusterName
         NoProxyClusterName: !GetAtt NoProxyRDSStack.Outputs.DBClusterName
       Tags:
@@ -487,12 +487,12 @@ Resources:
         PrivateSubnet2: !GetAtt LoadTestVPCStack.Outputs.PrivateSubnet2
         ProxyAccessLambda: !If
           - IsPython
-          - !GetAtt ProxyLambdaAccessStack.Outputs.PythonLambdaFunction
-          - !GetAtt ProxyLambdaAccessStack.Outputs.NodeJsLambdaFunction
+          - !GetAtt ProxyAccessStack.Outputs.PythonFunction
+          - !GetAtt ProxyAccessStack.Outputs.NodeJsFunction
         NoProxyAccessLambda: !If
           - IsPython
-          - !GetAtt NoProxyLambdaAccessStack.Outputs.PythonLambdaFunction
-          - !GetAtt NoProxyLambdaAccessStack.Outputs.NodeJsLambdaFunction
+          - !GetAtt NoProxyAccessStack.Outputs.PythonFunction
+          - !GetAtt NoProxyAccessStack.Outputs.NodeJsFunction
         ApiEndpointType: !Ref ApiEndpointType
       Tags:
         - Key: Project
@@ -516,15 +516,15 @@ Outputs:
     Description: Proxy tenant data access lambda function.
     Value: !If
       - IsPython
-      - !GetAtt ProxyLambdaAccessStack.Outputs.PythonLambdaFunction
-      - !GetAtt ProxyLambdaAccessStack.Outputs.NodeJsLambdaFunction
+      - !GetAtt ProxyAccessStack.Outputs.PythonFunction
+      - !GetAtt ProxyAccessStack.Outputs.NodeJsFunction
 
   NoProxyLambdaName:
     Description: NoProxy tenant data access lambda function.
     Value: !If
       - IsPython
-      - !GetAtt NoProxyLambdaAccessStack.Outputs.PythonLambdaFunction
-      - !GetAtt NoProxyLambdaAccessStack.Outputs.NodeJsLambdaFunction
+      - !GetAtt NoProxyAccessStack.Outputs.PythonFunction
+      - !GetAtt NoProxyAccessStack.Outputs.NodeJsFunction
     Condition: IsLoadTest
 
   ProxyDB:

--- a/cfn/main.template
+++ b/cfn/main.template
@@ -3,7 +3,7 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: Builds Amazon RDS Proxy with a Load Test (uksb-1rkqqff0c).
 
 Metadata:
-  Version: 0.0.4
+  Version: 0.0.5
 
   AWS::CloudFormation::Interface:
     ParameterGroups:


### PR DESCRIPTION
Creating static name for access lambda function, so as to increase the maximum number of allowed characters in the stack name to 20


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
